### PR TITLE
ラベル捜索の高速化

### DIFF
--- a/db/recruitment.go
+++ b/db/recruitment.go
@@ -252,9 +252,13 @@ func (r *Recruitment) ExpireAtTime(timezone *time.Location) string {
 }
 
 func fetchEmptyLabel(channel *Channel) (uint, error) {
-	recruitments, err := FetchActiveRecruitments(channel)
+	recruitments := []*Recruitment{}
+	err := dbs.
+		Select("label").
+		Find(&recruitments, "channel_id=? AND active=?", channel.ID, true).
+		Error
 	if err != nil {
-		return 0, err
+		return 0, errors.WithStack(err)
 	}
 	maxLabel := uint(1)
 	for _, recruitment := range recruitments {


### PR DESCRIPTION
参加データなど含めて取得していたので、ラベルだけ取得するように変更